### PR TITLE
Make extension work again, add Dutch aria-label detection

### DIFF
--- a/js/sort-users.js
+++ b/js/sort-users.js
@@ -1,9 +1,6 @@
-;(function () {
+; (function () {
     setInterval(() => {
-        let participants = document.querySelector('[aria-label="Participants"]')
-        if (participants == null) {
-            participants = document.querySelector('[class="GvcuGe"]');
-        }
+        let participants = getParticipants(["Participants", "Deelnemers"]);
         if (participants) {
             let items = participants.querySelectorAll('[role="listitem"]');
             let user_name = null;
@@ -37,6 +34,24 @@
                     participants.insertBefore(participants.children[user_ind], participants.children[new_user_ind]);
                 }
             }
+        }
+
+        function getParticipants(possible_names) {
+            let participants = null;
+
+            // Try to find the participants list by its aria-label
+            for (let i = 0; i < possible_names.length; i++) {
+                participants = document.querySelector('[aria-label="' + possible_names[i] + '"]');
+                if (participants != null) {
+                    break;
+                }
+            }
+
+            // Fall back to the first element with class "GvcuGe" if no participants list is found
+            if (participants == null) {
+                participants = document.getElementsByClassName("GvcuGe")[0];
+            }
+            return participants;
         }
     }, 500)
 })()


### PR DESCRIPTION
I've been working on getting this extension to work properly on _my machine(TM)_. I noticed that although the extension loaded fine, it did not work because `document.querySelector('[class="GvcuGe"]')` returned null. I replaced it with `document.getElementsByClassName("GvcuGe")[0];`, which does work. Not sure why this is the case.

This PR also adds support for the Dutch aria-label "Deelnemers", however I can remove this if it's too niche.

I haven't yet tested this change with a Chromium browser. I'll try again tomorrow as I have no more meetings planned for today.