### PR TITLE
Migrate to manifest v3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,11 +19,18 @@
     "48": "icons/sort48.png",
     "128": "icons/sort128.png"
   },
-  "browser_action": {
+  "action": {
     "default_icon": "icons/sort48.png"
   },
   "web_accessible_resources": [
-    "js/sort-users.js"
+    {
+      "resources": [
+        "js/sort-users.js"
+      ],
+      "matches": [
+        "https://meet.google.com/*"
+      ]
+    }
   ],
-  "manifest_version": 2
+  "manifest_version": 3
 }


### PR DESCRIPTION
After these changes, it seems to load well in my Chrome.

Sadly, I was unable to properly test it myself: I only own several accounts with "External participant" status, and the extension seems to be a bit confused by these, and thinks they should be on the top anyway (because they have more `<span>` elements than usual participant items in the list).

I will do more testing on Monday. But I believe it should work as it was before already, so decided to send the PR right now.